### PR TITLE
Add more modes to support dumping images on CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+artifacts
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 artifacts
 .DS_Store
+tests/tmp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "twenty-twenty"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "ffmpeg-next",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,14 +49,14 @@ const CRATE_ENV_VAR: &str = "TWENTY_TWENTY";
 /// The different modes available for the TWENTY_TWENTY environment variable.
 #[derive(PartialEq)]
 enum Mode {
-    /// Overwrite the file we are comparing against, i.e. accept the changes of the diff.
-    Overwrite,
-    /// Store the files on disk when they don't match (for now make all paths relative to `artifacts/`).
-    StoreArtifactOnMismatch,
-    /// Store the files on disk always (for now make all paths relative to `artifacts/`).
-    StoreArtifact,
     /// Only assert the image diff is within the given threshold.
     Default,
+    /// Overwrite the file we are comparing against, i.e. accept the changes of the diff.
+    Overwrite,
+    /// Store the files on disk always (for now make all paths relative to `artifacts/`).
+    StoreArtifact,
+    /// Store the files on disk when they don't match (for now make all paths relative to `artifacts/`).
+    StoreArtifactOnMismatch,
 }
 
 /// Compare the contents of the file to the image provided.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,16 +46,16 @@ use ffmpeg_next as ffmpeg;
 
 const CRATE_ENV_VAR: &str = "TWENTY_TWENTY";
 
-/// The different modes available for the TWENTY_TWENTY environment variable
+/// The different modes available for the TWENTY_TWENTY environment variable.
 #[derive(PartialEq)]
 enum Mode {
     /// Overwrite the file we are comparing against, i.e. accept the changes of the diff.
     Overwrite,
-    /// Store the files on disk when they don't match (for now make all paths relative to `artifacts/`)
+    /// Store the files on disk when they don't match (for now make all paths relative to `artifacts/`).
     StoreArtifactOnMismatch,
-    /// Store the files on disk always (for now make all paths relative to `artifacts/`)
+    /// Store the files on disk always (for now make all paths relative to `artifacts/`).
     StoreArtifact,
-    /// Don't do anything
+    /// Only assert the image diff is within the given threshold.
     Default,
 }
 


### PR DESCRIPTION
Now in CI we can just set `TWENTY_TWENTY=store-artifact-on-mismatch` and later upload the images as artifacts. This helps if we want to visually compare the generated images.

`TWENTY_TWENTY=store-artifact` also exists to always write the new images to disk. 

We may want to make the directory for artifacts configurable, but this should be fine for our purposes for now.