### PR TITLE
Improve crate documentation/readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 # twenty-twenty
 
-The `twenty-twenty` library allows for visual regression testing of H.264 frames and images.
-It makes it easy to update the contents when they should be updated to match the new results.
+The `twenty-twenty` crate allows for visual regression testing of H.264 frames (enabled with the
+`h264` feature) as well as images. It makes it easy to update the contents when they should be
+updated to match the new results.
 
-Each function takes a score threshold, which is the lowest possible "score" you are willing for
-the image comparison to return. If the resulting score is less than the threshold, the test
-will fail. The score must be a number between 0 and 1. If the images are the exact same, the
+Each function takes a minimum permissible similarity, which is the lowest possible "score" you are
+willing for the image comparison to return. If the resulting score is less than the minimum, the
+test will fail. The score must be a number between 0 and 1. If the images are the exact same, the
 score will be 1.
 
-The underlying algorithm is SSIM, which is a perceptual metric that quantifies the image
-quality degradation that is caused by processing such as data compression or by losses in data
-transmission. More information can be found [here](https://en.wikipedia.org/wiki/Structural_similarity).
+The underlying algorithm is SSIM, which is a perceptual metric that quantifies the image quality
+degradation that is caused by processing such as data compression or by losses in data transmission.
+More information can be found [here](https://en.wikipedia.org/wiki/Structural_similarity).
 
-You will need `ffmpeg` installed on your system to use this library. This library uses
-the [ffmpeg bindings](https://docs.rs/ffmpeg-next/latest/ffmpeg_next/) in rust to convert the H.264 frames to images.
+To compare H.264 frames you will need `ffmpeg` installed on your system and the `h264` feature
+enabled to use this crate, which relies on the
+[Rust ffmpeg bindings](https://docs.rs/ffmpeg-next/latest/ffmpeg_next/) to convert the H.264 frames
+to images.
 
 Use it like this for an H.264 frame:
 
@@ -21,6 +24,7 @@ Use it like this for an H.264 frame:
 let actual = get_h264_frame();
 twenty_twenty::assert_h264_frame("tests/initial-grid.png", &actual, 0.9);
 ```
+
 Use it like this for an image:
 
 ```rust
@@ -28,15 +32,49 @@ let actual = get_image();
 twenty_twenty::assert_image("tests/dog1.png", &actual, 0.9);
 ```
 
-If the output doesn't match, the program will `panic!` and emit the
-difference in the score.
+If the output doesn't match, the program will `panic!` and emit the difference in the score.
 
 To accept the changes from `get_h264_frame()` or `get_image()`, run with `TWENTY_TWENTY=overwrite`.
 
+## Usage in tests
+
+1. Write a test, for example:
+
+```
+// tests/twenty_twenty.rs
+#[test]
+fn example_test() {
+    # fn get_image() -> image::DynamicImage {
+    #    image::io::Reader::open("tests/dog1.png").unwrap().decode().unwrap()
+    # }
+    let actual = get_image();
+    twenty_twenty::assert_image("tests/dog1.png", &actual, 0.9);
+}
+```
+
+2. Run the test and have it write `actual` to disk next to the file the test is in, in this case
+   `tests/dog1.png`:
+
+```sh
+TWENTY_TWENTY=overwrite cargo test example_test
+```
+
+3. Review the output image and ensure it is a correct reference image.
+
+4. Run `cargo test`. If the generated image changes and differs from the image written to disk, the
+   test will fail.
+
+## Storing artifacts in CI
+
+Use either `TWENTY_TWENTY=store-artifact` or `TWENTY_TWENTY=store-artifact-on-mismatch` to save
+artifacts to the `artifacts/` directory. The latter can be used to only store failing tests for
+review and repair.
+
 ## Publishing a new release
 
-We have a GitHub action that pushes our releases [here](https://github.com/KittyCAD/twenty-twenty/blob/main/.github/workflows/make-release.yml). It is triggered by
-pushing a new tag. So do the following:
+We have a GitHub action that pushes our releases
+[here](https://github.com/KittyCAD/twenty-twenty/blob/main/.github/workflows/make-release.yml). It
+is triggered by pushing a new tag. So do the following:
 
 1. Bump the version in `Cargo.toml`. Commit it and push it up to the repo.
 2. Create a tag with the new version: `git tag -sa v$(VERSION) -m "v$(VERSION)"`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! The `twenty-twenty` library allows for visual regression testing of H.264 frames and images.
+//! The `twenty-twenty` crate allows for visual regression testing of H.264 frames (enabled with the `h264` feature) as well as images.
 //! It makes it easy to update the contents when they should be updated to match the new results.
 //!
 //! Each function takes a minimum permissible similarity, which is the lowest possible "score" you are willing for
@@ -10,8 +10,8 @@
 //! quality degradation that is caused by processing such as data compression or by losses in data
 //! transmission. More information can be found [here](https://en.wikipedia.org/wiki/Structural_similarity).
 //!
-//! You will need `ffmpeg` installed on your system to use this library. This library uses
-//! the [ffmpeg bindings](https://docs.rs/ffmpeg-next/latest/ffmpeg_next/) in rust to convert the H.264 frames to images.
+//! To compare H.264 frames you will need `ffmpeg` installed on your system and the `h264` feature enabled to use this crate, which relies on
+//! the [Rust ffmpeg bindings](https://docs.rs/ffmpeg-next/latest/ffmpeg_next/) to convert the H.264 frames to images.
 //!
 //! Use it like this for an H.264 frame:
 //!
@@ -36,6 +36,36 @@
 //! difference in the score.
 //!
 //! To accept the changes from `get_h264_frame()` or `get_image()`, run with `TWENTY_TWENTY=overwrite`.
+//!
+//! # Usage in tests
+//!
+//! 1. Write a test, for example:
+//!
+//!   ```
+//!   // tests/twenty_twenty.rs
+//!   #[test]
+//!   fn example_test() {
+//!       # fn get_image() -> image::DynamicImage {
+//!       #    image::io::Reader::open("tests/dog1.png").unwrap().decode().unwrap()
+//!       # }
+//!       let actual = get_image();
+//!       twenty_twenty::assert_image("tests/dog1.png", &actual, 0.9);
+//!   }
+//!   ```
+//!
+//! 2. Run the test and have it write `actual` to disk next to the file the test is in, in this case `tests/dog1.png`:
+//!
+//!   ```sh
+//!   TWENTY_TWENTY=overwrite cargo test example_test
+//!   ```
+//!
+//! 3. Review the output image and ensure it is a correct reference image.
+//!
+//! 4. Run `cargo test`. If the generated image changes and differs from the image written to disk, the test will fail.
+//!
+//! # Storing artifacts in CI
+//!
+//! Use either `TWENTY_TWENTY=store-artifact` or `TWENTY_TWENTY=store-artifact-on-mismatch` to save artifacts to the `artifacts/` directory. The latter can be used to only store failing tests for review and repair.
 
 #![deny(missing_docs)]
 
@@ -74,11 +104,12 @@ impl std::str::FromStr for Mode {
 }
 
 /// Compare the contents of the file to the image provided.
-/// If the two are less similar than the `min_permissible_similarity` threshold,
+///
+/// `min_permissible_similarity` is a floating point value between `0.0` and `1.0`. If the two compared images are less similar than the `min_permissible_similarity` threshold,
 /// the test will fail.
-/// The `min_permissible_similarity` is a float between 0 and 1.
-/// The score is a float between 0 and 1.
-/// If the images are the exact same, the score will be 1.
+///
+/// The score is also a floating point value between `0.0` and `1.0`.
+/// If the images are identical, the score will be `1.0`.
 #[track_caller]
 pub fn assert_image<P: AsRef<std::path::Path>>(path: P, actual: &image::DynamicImage, min_permissible_similarity: f64) {
     if let Err(e) = assert_image_impl(path, actual, min_permissible_similarity) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,21 @@
-//! The `twenty-twenty` crate allows for visual regression testing of H.264 frames (enabled with the `h264` feature) as well as images.
-//! It makes it easy to update the contents when they should be updated to match the new results.
+//! The `twenty-twenty` crate allows for visual regression testing of H.264 frames (enabled with the
+//! `h264` feature) as well as images. It makes it easy to update the contents when they should be
+//! updated to match the new results.
 //!
-//! Each function takes a minimum permissible similarity, which is the lowest possible "score" you are willing for
-//! the image comparison to return. If the resulting score is less than the minimum, the test
-//! will fail. The score must be a number between 0 and 1. If the images are the exact same, the
-//! score will be 1.
+//! Each function takes a minimum permissible similarity, which is the lowest possible "score" you
+//! are willing for the image comparison to return. If the resulting score is less than the minimum,
+//! the test will fail. The score must be a number between 0 and 1. If the images are the exact
+//! same, the score will be 1.
 //!
-//! The underlying algorithm is SSIM, which is a perceptual metric that quantifies the image
-//! quality degradation that is caused by processing such as data compression or by losses in data
-//! transmission. More information can be found [here](https://en.wikipedia.org/wiki/Structural_similarity).
+//! The underlying algorithm is SSIM, which is a perceptual metric that quantifies the image quality
+//! degradation that is caused by processing such as data compression or by losses in data
+//! transmission. More information can be found
+//! [here](https://en.wikipedia.org/wiki/Structural_similarity).
 //!
-//! To compare H.264 frames you will need `ffmpeg` installed on your system and the `h264` feature enabled to use this crate, which relies on
-//! the [Rust ffmpeg bindings](https://docs.rs/ffmpeg-next/latest/ffmpeg_next/) to convert the H.264 frames to images.
+//! To compare H.264 frames you will need `ffmpeg` installed on your system and the `h264` feature
+//! enabled to use this crate, which relies on the [Rust ffmpeg
+//! bindings](https://docs.rs/ffmpeg-next/latest/ffmpeg_next/) to convert the H.264 frames to
+//! images.
 //!
 //! Use it like this for an H.264 frame:
 //!
@@ -32,10 +36,10 @@
 //! twenty_twenty::assert_image("tests/dog1.png", &actual, 0.9);
 //! ```
 //!
-//! If the output doesn't match, the program will `panic!` and emit the
-//! difference in the score.
+//! If the output doesn't match, the program will `panic!` and emit the difference in the score.
 //!
-//! To accept the changes from `get_h264_frame()` or `get_image()`, run with `TWENTY_TWENTY=overwrite`.
+//! To accept the changes from `get_h264_frame()` or `get_image()`, run with
+//! `TWENTY_TWENTY=overwrite`.
 //!
 //! # Usage in tests
 //!
@@ -53,7 +57,8 @@
 //!   }
 //!   ```
 //!
-//! 2. Run the test and have it write `actual` to disk next to the file the test is in, in this case `tests/dog1.png`:
+//! 2. Run the test and have it write `actual` to disk next to the file the test is in, in this case
+//!    `tests/dog1.png`:
 //!
 //!   ```sh
 //!   TWENTY_TWENTY=overwrite cargo test example_test
@@ -61,11 +66,14 @@
 //!
 //! 3. Review the output image and ensure it is a correct reference image.
 //!
-//! 4. Run `cargo test`. If the generated image changes and differs from the image written to disk, the test will fail.
+//! 4. Run `cargo test`. If the generated image changes and differs from the image written to disk,
+//!    the test will fail.
 //!
 //! # Storing artifacts in CI
 //!
-//! Use either `TWENTY_TWENTY=store-artifact` or `TWENTY_TWENTY=store-artifact-on-mismatch` to save artifacts to the `artifacts/` directory. The latter can be used to only store failing tests for review and repair.
+//! Use either `TWENTY_TWENTY=store-artifact` or `TWENTY_TWENTY=store-artifact-on-mismatch` to save
+//! artifacts to the `artifacts/` directory. The latter can be used to only store failing tests for
+//! review and repair.
 
 #![deny(missing_docs)]
 


### PR DESCRIPTION
Adds/changes a few things I noticed when coming to this crate as a new user:

- Mentions extra env var settings
- Tweaks a bit of the wording
- Adds an example of setting up a test
- Briefly mentions usage in CI

I have an autowrapper turned on which is hopefully ok to apply here.